### PR TITLE
Finish Codecov migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/doctrine-skeleton/actions"><img src="https://badgen.net/github/checks/contributte/doctrine-skeleton/master"></a>
-  <a href="https://coveralls.io/r/contributte/doctrine-skeleton"><img src="https://badgen.net/coveralls/c/github/contributte/doctrine-skeleton"></a>
+  <a href="https://codecov.io/gh/contributte/doctrine-skeleton"><img src="https://badgen.net/codecov/c/github/contributte/doctrine-skeleton"></a>
   <a href="https://packagist.org/packages/contributte/doctrine-skeleton"><img src="https://badgen.net/packagist/dm/contributte/doctrine-skeleton"></a>
   <a href="https://packagist.org/packages/contributte/doctrine-skeleton"><img src="https://badgen.net/packagist/v/contributte/doctrine-skeleton"></a>
 </p>

--- a/tests/.coveralls.yml
+++ b/tests/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-service_name: github-actions
-coverage_clover: coverage.xml
-json_path: coverage.json


### PR DESCRIPTION
## What changed
- switched the README coverage badge from Coveralls to Codecov
- removed the obsolete `tests/.coveralls.yml` file
- kept the existing reusable coverage workflow wiring because it already uses `nette-tester-coverage-v2`

## Why
- finishes the remaining Coveralls-to-Codecov cleanup for this repository
- removes stale Coveralls-specific config that is no longer used

Refs contributte/contributte#72