### PR TITLE
Use php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## Summary

Switch the Makefile coverage target from `phpdbg` to `php` so this repository follows the org-wide coverage runner update.

## Motivation

Issue #73 tracks removing `phpdbg` from Contributte coverage targets. Using `php` keeps the target aligned with the new expected invocation.

## Changes

- replace `-p phpdbg` with `-p php` in the `coverage` Makefile target
- keep the rest of the coverage command unchanged

## Testing

- [x] `make coverage` runs the updated command
- [ ] Coverage completes locally
- [ ] CI passes

Local note: `make coverage` currently fails in this environment because PHP is running without Xdebug, PCOV, or PHPDBG support.