### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.4"
       make: "init coverage"


### PR DESCRIPTION
## What changed
- Added `secrets: inherit` to the reusable coverage workflow call in `.github/workflows/coverage.yml`.

## Why
- This lets the reusable workflow access required inherited secrets during the issue #74 rollout.

Refs contributte/contributte#74