### PR TITLE
Docs: unify skeleton README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,32 @@
-![](https://heatbadger.now.sh/github/readme/contributte/doctrine-skeleton/)
+# Doctrine Skeleton
 
-<p align=center>
-  <a href="https://github.com/contributte/doctrine-skeleton/actions"><img src="https://badgen.net/github/checks/contributte/doctrine-skeleton/master"></a>
-  <a href="https://codecov.io/gh/contributte/doctrine-skeleton"><img src="https://badgen.net/codecov/c/github/contributte/doctrine-skeleton"></a>
-  <a href="https://packagist.org/packages/contributte/doctrine-skeleton"><img src="https://badgen.net/packagist/dm/contributte/doctrine-skeleton"></a>
-  <a href="https://packagist.org/packages/contributte/doctrine-skeleton"><img src="https://badgen.net/packagist/v/contributte/doctrine-skeleton"></a>
-</p>
-<p align=center>
-  <a href="https://packagist.org/packages/contributte/doctrine-skeleton"><img src="https://badgen.net/packagist/php/contributte/doctrine-skeleton"></a>
-  <a href="https://github.com/contributte/doctrine-skeleton"><img src="https://badgen.net/github/license/contributte/doctrine-skeleton"></a>
-  <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
-  <a href="https://bit.ly/cttfo"><img src="https://badgen.net/badge/support/forum/yellow"></a>
-  <a href="https://contributte.org/partners.html"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
-</p>
+Example Nette application with Nettrine DBAL, ORM, fixtures, and migrations configured for PostgreSQL and MariaDB.
 
-<p align=center>
-Website 🚀 <a href="https://contributte.org">contributte.org</a> | Contact 👨🏻‍💻 <a href="https://f3l1x.io">f3l1x.io</a> | Twitter 🐦 <a href="https://twitter.com/contributte">@contributte</a>
-</p>
+## Requirements
 
-<p align=center>
-	<a href="https://examples.contributte.org/doctrine-skeleton/">examples.contributte.org/doctrine-skeleton/</a>
-</p>
+- PHP 8.4+
+- [Composer](https://getcomposer.org/)
+- PostgreSQL 15 and MariaDB 10.10, either installed locally or started with Docker Compose
 
-<p align=center>
-	<img src="https://api.microlink.io?url=https%3A%2F%2Fexamples.contributte.org%2Fdoctrine-skeleton%2F&overlay.browser=light&screenshot=true&meta=false&embed=screenshot.url"/>
-</p>
-
------
-
-## Introduction
-
-This is a simple application with basic setup of [Doctrine](https://www.doctrine-project.org/) and [Nette](https://nette.org/).
-
-To test this application, follow these steps:
-
-1. Create a new project.
-2. Install dependencies.
-3. Setup configuration.
-4. Run the application.
-
-## Installation
-
-You will need `PHP 8.4+` and [Composer](https://getcomposer.org/) and [Git](https://git-scm.com/) installed.
-
-Install this application using **Composer** or **Git**.
-
-**Composer**
-
-Create project using composer.
+## Create a project
 
 ```bash
 composer create-project -s dev contributte/doctrine-skeleton acme
-```
-
-**Git**
-
-```bash
-git clone git@github.com:contributte/doctrine-skeleton.git acme
-```
-
-Now you have application installed. It's time to install dependencies.
-
-```bash
 cd acme
-composer install
+make project
 ```
 
-## Configuration
+`make project` installs dependencies and creates writable `var/tmp` and `var/log` directories.
 
-This application uses 2 databases PostgreSQL and MariaDB. You have to configure them in `local.neon`.
-This is how default configuration looks like.
+## Database configuration
+
+Copy the local configuration template:
+
+```bash
+make init
+```
+
+For the included Docker Compose services, uncomment and use the following values in `config/local.neon`:
 
 ```neon
 parameters:
@@ -89,56 +46,50 @@ parameters:
 		dbname: demomariadb
 ```
 
-## Development
+The base configuration selects the PostgreSQL `default` connection for migrations. Override `migration.db` and `migration.manager` locally when working with the MariaDB connection.
 
-The easiest way is to use php built-in web server.
+## Docker Compose
+
+The tracked `docker-compose.yml` starts only the database services:
 
 ```bash
-# make dev
-php -S 0.0.0.0:8080 -t www
+make docker-up
 ```
 
-Then visit [http://localhost:8080](http://localhost:8080) in your browser.
+It exposes PostgreSQL on `localhost:5432` (`demopostgres`) and MariaDB on `localhost:3306` (`demomariadb`). Both use the `contributte` username and password.
 
-## Usage
+## Migrations
 
-To setup this application properly, you have to execute migrations.
-
-1. For **PostgreSQL** database.
+Run migrations for PostgreSQL:
 
 ```bash
-# run migrations
 NETTE__MIGRATION__DB=postgres NETTE__MIGRATION__MANAGER=default bin/console migrations:migrate
-
-# or generate new migration
-#NETTE__MIGRATION__DB=postgres NETTE__MIGRATION__MANAGER=default bin/console migrations:diff
 ```
 
-2. For **MariaDB** database.
+Run migrations for MariaDB:
 
 ```bash
-# run migrations
 NETTE__MIGRATION__DB=mariadb NETTE__MIGRATION__MANAGER=second bin/console migrations:migrate
-
-# or generate new migration
-#NETTE__MIGRATION__DB=mariadb NETTE__MIGRATION__MANAGER=second bin/console migrations:diff
 ```
 
-## Screenshots
+Generate a migration by replacing `migrations:migrate` with `migrations:diff` and keeping the matching database and manager variables.
 
-![](.docs/screenshot.png)
+## Development and quality checks
 
-## Maintenance
+Start the application at <http://localhost:8080>:
 
-See [how to contribute](https://contributte.org/contributing.html) to this package.
+```bash
+make dev
+```
 
-This package is currently maintaining by these authors.
+Run static analysis and coding-standard checks:
 
-<a href="https://github.com/f3l1x">
-    <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
-</a>
+```bash
+make qa
+```
 
------
+Run tests:
 
-Consider to [support](https://contributte.org/partners.html) **contributte** development team.
-Also thank you for using this project.
+```bash
+make tests
+```

--- a/README.md
+++ b/README.md
@@ -13,40 +13,35 @@ Example Nette application with Nettrine DBAL, ORM, fixtures, and migrations conf
 ```bash
 composer create-project -s dev contributte/doctrine-skeleton acme
 cd acme
-make project
-```
-
-`make project` installs dependencies and creates writable `var/tmp` and `var/log` directories.
-
-## Database configuration
-
-Copy the local configuration template:
-
-```bash
+make setup
 make init
 ```
 
-For the included Docker Compose services, uncomment and use the following values in `config/local.neon`:
+`composer create-project` already installs the dependencies. `make setup` creates writable `var/tmp` and `var/log` directories without running Composer a second time, and `make init` copies the local configuration template.
+
+## Database configuration
+
+The application configures two DBAL connections and two entity managers: `default` uses PostgreSQL and `second` uses MariaDB. For native PHP clients connecting to the included Docker Compose databases, uncomment and use these local overrides in `config/local.neon`:
 
 ```neon
 parameters:
 	postgres:
 		driver: pdo_pgsql
-		host: 0.0.0.0
+		host: localhost
 		port: 5432
 		user: contributte
 		password: contributte
 		dbname: demopostgres
 	mariadb:
 		driver: mysqli
-		host: 0.0.0.0
+		host: localhost
 		port: 3306
 		user: contributte
 		password: contributte
 		dbname: demomariadb
 ```
 
-The base configuration selects the PostgreSQL `default` connection for migrations. Override `migration.db` and `migration.manager` locally when working with the MariaDB connection.
+These database names and credentials match `docker-compose.yml`. The environment variables in the migration commands below select the matching migration directory and entity manager without changing the local file.
 
 ## Docker Compose
 
@@ -63,13 +58,13 @@ It exposes PostgreSQL on `localhost:5432` (`demopostgres`) and MariaDB on `local
 Run migrations for PostgreSQL:
 
 ```bash
-NETTE__MIGRATION__DB=postgres NETTE__MIGRATION__MANAGER=default bin/console migrations:migrate
+NETTE__MIGRATION__DB=postgres NETTE__MIGRATION__MANAGER=default bin/console migrations:migrate --no-interaction
 ```
 
 Run migrations for MariaDB:
 
 ```bash
-NETTE__MIGRATION__DB=mariadb NETTE__MIGRATION__MANAGER=second bin/console migrations:migrate
+NETTE__MIGRATION__DB=mariadb NETTE__MIGRATION__MANAGER=second bin/console migrations:migrate --no-interaction
 ```
 
 Generate a migration by replacing `migrations:migrate` with `migrations:diff` and keeping the matching database and manager variables.
@@ -81,6 +76,8 @@ Start the application at <http://localhost:8080>:
 ```bash
 make dev
 ```
+
+Open the page and click **Create random user**. A successful PostgreSQL write displays **Saved** and adds a new row to the users table; the page reads and combines rows through both entity managers.
 
 Run static analysis and coding-standard checks:
 


### PR DESCRIPTION
## Scope
- Avoid a duplicate Composer install during project creation.
- Document both DBAL connections/entity managers and native-client `localhost` overrides matching Compose databases `demopostgres` and `demomariadb`.
- Run migrations explicitly for both PostgreSQL/default and MariaDB/second.
- Document the browser verification path: **Create random user**, **Saved**, and a new users-table row.

## Validation
- Repository-backed README evaluator assertions passed against `Makefile`, `config/doctrine.neon`, application handlers/templates, migrations, and `docker-compose.yml`.
- `git diff --check` passed; PR changes remain limited to `README.md`.
- `docker compose config --quiet` and `composer validate --no-check-publish` passed.
- `make qa`/`make tests` could not run because this worktree has no installed `vendor/bin` tools.

## Runtime blocker
- Clean Docker smoke was not executed because the Docker daemon is unavailable (`/var/run/docker.sock`); no services or data were modified. Runtime statements are repository-backed and unexecuted in this environment.